### PR TITLE
replace python install by pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ conda activate jax-env
 ```
 **4-** Jax-ReaxFF is installed with the following command:
 ```
-python setup.py install
+pip install .
 ```
 After the setup, Jax-ReaxFF can be accessed via command line interface(CLI) with **jaxreaxff**
 


### PR DESCRIPTION
`pip install .` is, in general, preferred over `python setup.py install` as it is more flexible. For example, a force reinstall or uninstalling is much more convenient and flexible using the `pip`.