### PR TITLE
Fix for installed scipy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ INSTALL_REQUIRES = [
   'jax_md @ git+https://github.com/cagrikymk/jax-md.git@reaxff_dev#egg=jax_md',
   'numba>=0.56',
   'numpy',
-  'scipy>=1.2.1',
+  'scipy>=1.2.1,<=1.12.0',
   'tabulate>=0.8.9',
   'frozendict',
   'tqdm',


### PR DESCRIPTION
scipy.linag.tril is missing for scipy > v1.12.0 (see, e.g., https://github.com/octo-models/octo/issues/71).

This PR pins the installed version to at most v1.12.0.  This change can be removed in the future if the dependent code instead switches to using numpy.tril for newer versions of numpy (https://numpy.org/doc/stable/reference/generated/numpy.tril.html).